### PR TITLE
Fix some issues with non-deployable curved solar panels (NIV-3 & NIV-18)

### DIFF
--- a/ModuleCurvedSolarPanel.cs
+++ b/ModuleCurvedSolarPanel.cs
@@ -81,6 +81,9 @@ namespace NearFutureSolar
         // Deploy Panels
         public void Deploy()
         {
+            if (!Deployable)
+                return;
+
             foreach (AnimationState deployState in deployStates)
             {
                 deployState.speed = 1;
@@ -91,6 +94,9 @@ namespace NearFutureSolar
         // Retract Panels
         public void Retract()
         {
+            if (!Deployable)
+                return;
+
             foreach (AnimationState deployState in deployStates)
             {
                 deployState.speed = -1;


### PR DESCRIPTION
4dfcac1 hides the GUI buttons for "Deploy Panels", "Retract Panels", and "Toggle Panels" if the part does not have `Deployable = true`.

859fb13 makes it so that even if someone tried to use Action Groups to deploy/retract/toggle a non-deployable part, there won't be a `NullReferenceException` (without this patch, `Deploy` and `Retract` could get called, and `deployStates` would be `null`).

(Side note: I wanted to see if there was a way to hide the actions in the VAB Action Group editor entirely, but interestingly, even Squad's own non-deployable solar panel shows deploy/retract/toggle actions. So I guess hiding the actions isn't important, as they don't do anything now anyway.)

23d4e7f fixes a small typo in the documentation for `Toggle`.
