### PR TITLE
Specify version file in netkan

### DIFF
--- a/CKAN/NearFutureSolar-Core.netkan
+++ b/CKAN/NearFutureSolar-Core.netkan
@@ -6,7 +6,7 @@
     "abstract"            : "This is the Near Future Solar plugin stand-alone, for adding functionality to other mods. It contains no parts and does nothing by itself.",
     "author"              : "Nertea",
     "license"             : "MIT",
-    "$vref"               : "#/ckan/ksp-avc",
+    "$vref"               : "#/ckan/ksp-avc/NearFutureSolar.version",
     "recommends": [
         { "name" : "NearFutureSolar" }
     ],


### PR DESCRIPTION
We just got an inflation error for this module:

> Too many .version files located: GameData/NearFutureSolar/Versioning/NearFutureSolar.version, GameData/B9PartSwitch/B9PartSwitch.version

This PR tells it which one to use.